### PR TITLE
Allow Rails 5.2 in gemspec

### DIFF
--- a/linkshare-oauth2-api.gemspec
+++ b/linkshare-oauth2-api.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", ">= 4.2", "< 5.2"
+  s.add_dependency "rails", ">= 4.2", "< 5.3"
   s.add_dependency "oauth2", "~> 1.3"
   
   s.add_development_dependency "awesome_print"


### PR DESCRIPTION
rails5.2アップグレードに伴う対応となります